### PR TITLE
add pkg-config support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,3 +8,13 @@ target_include_directories(${PROJECT_NAME} INTERFACE include)
 
 # What to install
 install(DIRECTORY include/makestuff DESTINATION include)
+
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/common.pc.in
+  ${CMAKE_CURRENT_BINARY_DIR}/common.pc
+@ONLY)
+
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/common.pc
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+)

--- a/common.pc.in
+++ b/common.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include
+
+Name: common
+Description: Top-level includes, stuff that almost everything else needs.
+Version: 20170708
+Cflags: -I${includedir}
+


### PR DESCRIPTION
One classic way to detect and to obtain required parameters at build time requirements, to use a library, is through `pkg-config`.
This approach is `Linux` and `msys2` compatible.
This PR add a pc.in file filled with prefix and all required informations, this one is installed in `${CMAKE_INSTALL_LIBDIR}/pkgconfig`